### PR TITLE
use literal_eval instead of eval

### DIFF
--- a/week1/week1-MultilabelClassification.ipynb
+++ b/week1/week1-MultilabelClassification.ipynb
@@ -118,6 +118,7 @@
    },
    "outputs": [],
    "source": [
+    "from ast import literal_eval\n",
     "import pandas as pd\n",
     "import numpy as np"
    ]
@@ -132,7 +133,7 @@
    "source": [
     "def read_data(filename):\n",
     "    data = pd.read_csv(filename, sep='\\t')\n",
-    "    data['tags'] = data['tags'].apply(eval)\n",
+    "    data['tags'] = data['tags'].apply(literal_eval)\n",
     "    return data"
    ]
   },


### PR DESCRIPTION
Remove usage of `eval` to evaluate tags. Usage of `eval` represents a security risk and should not generally be used in any code. This replaces `eval` with `literal_eval` which is totally safe. 